### PR TITLE
feat: create models.json registry with FLUX dev-lora entry

### DIFF
--- a/src/ml/models.json
+++ b/src/ml/models.json
@@ -1,0 +1,16 @@
+{
+  "replicate:flux-dev-lora": {
+    "name": "FLUX Dev (LoRA)",
+    "provider": "replicate",
+    "replicateModel": "black-forest-labs/flux-dev-lora",
+    "capabilities": {
+      "supportsLora": true,
+      "maxImages": 4
+    },
+    "settings": [
+      {"key": "num_inference_steps", "label": "Steps", "type": "range", "min": 10, "max": 50, "default": 28},
+      {"key": "guidance_scale", "label": "Guidance", "type": "range", "min": 1, "max": 10, "step": 0.5, "default": 3.5},
+      {"key": "aspect_ratio", "label": "Aspect Ratio", "type": "select", "options": ["1:1", "16:9", "9:16"], "default": "1:1"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `src/ml/models.json` registry with `replicate:flux-dev-lora` model configuration
- Includes capabilities (`supportsLora: true`, `maxImages: 4`)
- Defines settings schema for inference steps, guidance scale, and aspect ratio
- Follows Director Mode specification section 1.2 structure exactly

## Implementation Details
The models.json registry provides:
- Model metadata (name, provider, replicate model ID)
- Capability flags for feature support
- Dynamic settings schema for auto-generating frontend forms

## Test Plan
- [x] File structure matches spec section 1.2
- [x] JSON syntax is valid
- [x] FLUX dev-lora entry includes all required fields

Resolves #11 (Director Mode - Issue #11)
Parent Issue: #9 (Director Mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)