### PR TITLE
feat: add Asset Types CRUD HTTP routes for Director Mode (Issue #13)

### DIFF
--- a/convex/assetTypes.ts
+++ b/convex/assetTypes.ts
@@ -1,0 +1,80 @@
+import { v } from "convex/values";
+import { internalMutation, internalQuery } from "./_generated/server";
+
+// Create a new Asset Type
+export const create = internalMutation({
+  args: {
+    name: v.string(),
+    description: v.optional(v.string()),
+    prePrompt: v.string(),
+    postPrompt: v.string(),
+    model: v.string(),                    // "replicate:flux-dev-lora"
+    modelSettings: v.any(),               // Model-specific params
+    loraId: v.optional(v.id("loras")),
+    qualityPreset: v.optional(v.string()),
+    isActive: v.boolean(),
+    createdAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("assetTypes", args);
+  },
+});
+
+// Get an Asset Type by ID
+export const get = internalQuery({
+  args: { id: v.id("assetTypes") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
+});
+
+// List Asset Types with optional filters
+export const list = internalQuery({
+  args: {
+    activeOnly: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    let query = ctx.db.query("assetTypes");
+
+    // Use the by_active index when filtering by activeOnly
+    if (args.activeOnly !== undefined) {
+      query = query.withIndex("by_active", (q) => q.eq("isActive", args.activeOnly));
+    }
+
+    const results = await query.collect();
+
+    // Sort by createdAt descending (newest first)
+    return results.sort((a, b) => b.createdAt - a.createdAt);
+  },
+});
+
+// Update an Asset Type
+export const update = internalMutation({
+  args: {
+    id: v.id("assetTypes"),
+    name: v.optional(v.string()),
+    description: v.optional(v.string()),
+    prePrompt: v.optional(v.string()),
+    postPrompt: v.optional(v.string()),
+    model: v.optional(v.string()),
+    modelSettings: v.optional(v.any()),
+    loraId: v.optional(v.id("loras")),
+    qualityPreset: v.optional(v.string()),
+    isActive: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const { id, ...updates } = args;
+    const filteredUpdates = Object.fromEntries(
+      Object.entries(updates).filter(([_, value]) => value !== undefined)
+    );
+    await ctx.db.patch(id, filteredUpdates);
+  },
+});
+
+// Soft delete an Asset Type by setting isActive to false
+export const deleteById = internalMutation({
+  args: { id: v.id("assetTypes") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.id, { isActive: false });
+  },
+});

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -4,6 +4,85 @@ import { internal } from "./_generated/api";
 
 const http = httpRouter();
 
+// Asset Types endpoints
+http.route({
+  path: "/api/asset-types/create",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const body = await request.json();
+    const id = await ctx.runMutation(internal.assetTypes.create, body);
+    return new Response(JSON.stringify({ id }), {
+      headers: { "Content-Type": "application/json" }
+    });
+  }),
+});
+
+http.route({
+  path: "/api/asset-types/list",
+  method: "GET",
+  handler: httpAction(async (ctx, request) => {
+    const url = new URL(request.url);
+    const activeOnly = url.searchParams.get("activeOnly");
+
+    const data = await ctx.runQuery(internal.assetTypes.list, {
+      activeOnly: activeOnly === "true" ? true : activeOnly === "false" ? false : undefined
+    });
+    return new Response(JSON.stringify(data), {
+      headers: { "Content-Type": "application/json" }
+    });
+  }),
+});
+
+http.route({
+  path: "/api/asset-types/get",
+  method: "GET",
+  handler: httpAction(async (ctx, request) => {
+    const url = new URL(request.url);
+    const id = url.searchParams.get("id");
+    if (!id) {
+      return new Response(JSON.stringify({ error: "id parameter required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+    const data = await ctx.runQuery(internal.assetTypes.get, { id });
+    return new Response(JSON.stringify(data), {
+      headers: { "Content-Type": "application/json" }
+    });
+  }),
+});
+
+http.route({
+  path: "/api/asset-types/update",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const body = await request.json();
+    await ctx.runMutation(internal.assetTypes.update, body);
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { "Content-Type": "application/json" }
+    });
+  }),
+});
+
+http.route({
+  path: "/api/asset-types/delete",
+  method: "DELETE",
+  handler: httpAction(async (ctx, request) => {
+    const url = new URL(request.url);
+    const id = url.searchParams.get("id");
+    if (!id) {
+      return new Response(JSON.stringify({ error: "id parameter required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+    await ctx.runMutation(internal.assetTypes.deleteById, { id });
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { "Content-Type": "application/json" }
+    });
+  }),
+});
+
 // LoRA endpoints
 http.route({
   path: "/api/loras/create",


### PR DESCRIPTION
## Summary
- Implements Issue #13: Add Convex HTTP routes for Asset Types CRUD operations
- Created `convex/assetTypes.ts` with complete CRUD operations
- Added 5 HTTP routes to `convex/http.ts` following existing patterns

## Implementation Details

### New File: `convex/assetTypes.ts`
- **create**: Insert new Asset Type with full schema support
- **get**: Retrieve single Asset Type by ID  
- **list**: List Asset Types with optional `activeOnly` filter
- **update**: Update Asset Type with partial updates
- **deleteById**: Soft delete by setting `isActive: false` (per spec)

### Updated File: `convex/http.ts`
Added 5 new HTTP routes following existing LoRA endpoint patterns:

| Route | Method | Purpose |
|-------|--------|---------|
| `/api/asset-types/create` | POST | Create new Asset Type |
| `/api/asset-types/list` | GET | List Asset Types (supports `?activeOnly=true/false`) |
| `/api/asset-types/get` | GET | Get single Asset Type by `?id=X` |
| `/api/asset-types/update` | POST | Update existing Asset Type |
| `/api/asset-types/delete` | DELETE | Soft delete Asset Type by `?id=X` |

## Test plan
- [ ] Test Asset Type creation via POST /api/asset-types/create
- [ ] Test Asset Type listing via GET /api/asset-types/list
- [ ] Test Asset Type retrieval via GET /api/asset-types/get?id=X
- [ ] Test Asset Type update via POST /api/asset-types/update
- [ ] Test Asset Type soft deletion via DELETE /api/asset-types/delete?id=X
- [ ] Verify error handling for missing parameters
- [ ] Verify activeOnly filter works correctly

## Notes
- All routes return consistent JSON responses with proper error handling
- Follows the same patterns established by existing LoRA endpoints
- Implements soft deletion as specified in Director Mode spec section 1.3
- Schema already existed in `convex/schema.ts`, only needed to add the backend logic

Relates to Director Mode Parent Issue #9 - Phase 1: Data Model & Backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)