### PR TITLE
feat: refactor index.html with history sidebar layout (Issue #19)

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -5,12 +5,13 @@
 
 // State
 const state = {
-  activeTab: 'generate',
   loras: [],
   currentJob: null,
   history: [],
-  favorites: [],
+  historyFilter: 'all', // 'all' or 'favorites'
   isConnected: false,
+  assetTypes: [], // Loaded from API
+  currentAssetType: null, // Currently selected asset type with pre/post prompts
 };
 
 // DOM Elements
@@ -19,13 +20,14 @@ const $$ = (selector) => document.querySelectorAll(selector);
 
 // Initialize
 document.addEventListener('DOMContentLoaded', async () => {
-  setupTabs();
   setupGenerate();
-  setupHistory();
-  setupFavorites();
+  setupPromptBuilder();
+  setupHistorySidebar();
 
   await checkHealth();
-  await loadLoras(); // Still needed for LoRA selector in Generate tab
+  await loadAssetTypes();
+  await loadLoras();
+  await loadHistorySidebar();
 });
 
 // === Health Check ===
@@ -47,30 +49,278 @@ function updateStatusIndicator(status) {
   dot.className = `status-dot ${status}`;
 }
 
-// === Tab Navigation ===
-function setupTabs() {
-  $$('.nav-tab').forEach((tab) => {
-    tab.addEventListener('click', () => {
-      const tabName = tab.dataset.tab;
-      switchTab(tabName);
+// === History Sidebar ===
+function setupHistorySidebar() {
+  // Filter buttons
+  $$('.filter-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const filter = btn.dataset.filter;
+      state.historyFilter = filter;
+
+      // Update active state
+      $$('.filter-btn').forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+
+      renderHistorySidebar();
     });
   });
 }
 
-function switchTab(tabName) {
-  // Update nav
-  $$('.nav-tab').forEach((t) => t.classList.remove('active'));
-  $(`.nav-tab[data-tab="${tabName}"]`).classList.add('active');
+async function loadHistorySidebar() {
+  try {
+    const result = await API.getHistory();
+    const items = result.data || result.items || result || [];
+    state.history = Array.isArray(items) ? items : [];
+    renderHistorySidebar();
+  } catch (error) {
+    console.error('Failed to load history:', error);
+    state.history = [];
+    renderHistorySidebar();
+  }
+}
 
-  // Update content
-  $$('.tab-content').forEach((c) => c.classList.add('hidden'));
-  $(`#tab-${tabName}`).classList.remove('hidden');
+function renderHistorySidebar() {
+  const list = $('#history-list');
+  const empty = $('#history-empty');
 
-  state.activeTab = tabName;
+  // Filter history based on current filter
+  let filteredHistory = state.history;
+  if (state.historyFilter === 'favorites') {
+    filteredHistory = state.history.filter((item) => item.isFavorite);
+  }
 
-  // Load data for tab
-  if (tabName === 'history') loadHistory();
-  if (tabName === 'favorites') loadFavorites();
+  if (filteredHistory.length === 0) {
+    list.innerHTML = '';
+    empty.classList.remove('hidden');
+    return;
+  }
+
+  empty.classList.add('hidden');
+  list.innerHTML = filteredHistory.map((item) => {
+    const thumb = item.thumbnail || item.images?.[0]?.url || '';
+    const thumbUrl = thumb.startsWith('http') ? thumb : (thumb ? `${API.baseUrl}${thumb}` : '');
+    const isFavorite = item.isFavorite || false;
+
+    return `
+      <div class="history-sidebar-item" data-id="${item._id || item.id}">
+        ${thumbUrl ? `<img class="history-sidebar-thumb" src="${thumbUrl}" alt="">` : '<div class="history-sidebar-thumb"></div>'}
+        <div class="history-sidebar-info">
+          <div class="history-sidebar-prompt">${item.userPrompt || item.prompt || ''}</div>
+          <div class="history-sidebar-meta">
+            <span>${formatRelativeTime(item.createdAt || item.created_at)}</span>
+          </div>
+        </div>
+        <div class="history-sidebar-actions">
+          <button class="history-action-btn ${isFavorite ? 'favorited' : ''}" onclick="toggleHistoryFavorite('${item._id || item.id}')" title="Favorite">
+            ${isFavorite ? '★' : '☆'}
+          </button>
+          <button class="history-action-btn" onclick="regenerateFromHistory('${item._id || item.id}')" title="Regenerate">
+            ↻
+          </button>
+          <button class="history-action-btn delete" onclick="deleteHistoryItem('${item._id || item.id}')" title="Delete">
+            ×
+          </button>
+        </div>
+      </div>
+    `;
+  }).join('');
+}
+
+function formatRelativeTime(timestamp) {
+  if (!timestamp) return '';
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+// History Actions (to be connected to API in Issue #13)
+async function toggleHistoryFavorite(id) {
+  console.log('Toggle favorite:', id);
+  // TODO: Implement in Issue #13
+}
+
+async function regenerateFromHistory(id) {
+  console.log('Regenerate:', id);
+  // TODO: Implement in Issue #13
+}
+
+async function deleteHistoryItem(id) {
+  console.log('Delete:', id);
+  // TODO: Implement in Issue #13
+}
+
+// === Asset Types & Prompt Builder ===
+
+/**
+ * Default asset types (used until API integration in Issue #12)
+ * Each asset type has pre/post prompts that wrap the user's input
+ */
+const DEFAULT_ASSET_TYPES = [
+  {
+    id: 'product',
+    name: 'Product Illustrations',
+    prePrompt: 'A clean, modern product illustration of',
+    postPrompt: ', minimalist style, white background, professional lighting',
+  },
+  {
+    id: 'icons',
+    name: 'Icons (Fluent 2)',
+    prePrompt: 'A Fluent 2 design system icon of',
+    postPrompt: ', simple shapes, consistent stroke width, monochrome',
+  },
+  {
+    id: 'logo',
+    name: 'Logo Illustrations',
+    prePrompt: 'A modern logo design featuring',
+    postPrompt: ', vector style, scalable, brand-appropriate',
+  },
+  {
+    id: 'premium',
+    name: 'Premium Illustrations',
+    prePrompt: 'A premium, high-quality illustration of',
+    postPrompt: ', detailed, artistic, publication-ready',
+  },
+];
+
+/**
+ * Load asset types from API (falls back to defaults)
+ */
+async function loadAssetTypes() {
+  try {
+    // Try to load from API (Issue #12 will implement this)
+    const result = await API.listAssetTypes?.();
+    if (result?.data && Array.isArray(result.data) && result.data.length > 0) {
+      state.assetTypes = result.data;
+    } else {
+      state.assetTypes = DEFAULT_ASSET_TYPES;
+    }
+  } catch (error) {
+    console.log('Using default asset types (API not available)');
+    state.assetTypes = DEFAULT_ASSET_TYPES;
+  }
+
+  populateAssetTypeSelector();
+  updatePromptBuilder();
+}
+
+/**
+ * Populate the asset type dropdown from state
+ */
+function populateAssetTypeSelector() {
+  const select = $('#asset-type');
+  if (!select) return;
+
+  select.innerHTML = state.assetTypes
+    .map((at) => `<option value="${at.id || at._id}">${at.name}</option>`)
+    .join('');
+
+  // Set initial current asset type
+  if (state.assetTypes.length > 0) {
+    state.currentAssetType = state.assetTypes[0];
+  }
+}
+
+/**
+ * Setup prompt builder event listeners
+ */
+function setupPromptBuilder() {
+  const assetTypeSelect = $('#asset-type');
+  const promptInput = $('#prompt');
+
+  if (assetTypeSelect) {
+    assetTypeSelect.addEventListener('change', () => {
+      const selectedId = assetTypeSelect.value;
+      state.currentAssetType = state.assetTypes.find(
+        (at) => (at.id || at._id) === selectedId
+      );
+      updatePromptBuilder();
+    });
+  }
+
+  if (promptInput) {
+    promptInput.addEventListener('input', () => {
+      updateCombinedPromptPreview();
+    });
+  }
+}
+
+/**
+ * Update the prompt builder UI with current asset type's pre/post prompts
+ */
+function updatePromptBuilder() {
+  const preLabel = $('#pre-prompt-label');
+  const postLabel = $('#post-prompt-label');
+
+  if (!state.currentAssetType) {
+    if (preLabel) preLabel.textContent = '';
+    if (postLabel) postLabel.textContent = '';
+    updateCombinedPromptPreview();
+    return;
+  }
+
+  const prePrompt = state.currentAssetType.prePrompt || '';
+  const postPrompt = state.currentAssetType.postPrompt || '';
+
+  if (preLabel) preLabel.textContent = prePrompt;
+  if (postLabel) postLabel.textContent = postPrompt;
+
+  updateCombinedPromptPreview();
+}
+
+/**
+ * Update the combined prompt preview
+ */
+function updateCombinedPromptPreview() {
+  const preview = $('#combined-prompt-preview');
+  if (!preview) return;
+
+  const userPrompt = $('#prompt')?.value || '';
+  const combined = buildCombinedPrompt(userPrompt);
+
+  if (combined) {
+    preview.textContent = combined;
+  } else {
+    preview.textContent = '';
+  }
+}
+
+/**
+ * Build combined prompt from pre + user + post
+ * Concatenation Rules (from spec 3.2):
+ * - Empty pre/post: omit entirely (no leading/trailing space)
+ * - Formula: "{pre} {user} {post}".strip()
+ *
+ * @param {string} userPrompt - The user's input prompt
+ * @returns {string} The combined prompt
+ */
+function buildCombinedPrompt(userPrompt) {
+  const pre = state.currentAssetType?.prePrompt?.trim() || '';
+  const post = state.currentAssetType?.postPrompt?.trim() || '';
+  const user = userPrompt?.trim() || '';
+
+  // Build parts array, filtering out empty strings
+  const parts = [pre, user, post].filter((p) => p.length > 0);
+
+  // Join with single space and trim
+  return parts.join(' ').trim();
+}
+
+/**
+ * Get the combined prompt for generation
+ * @returns {string} The combined prompt ready for API
+ */
+function getCombinedPromptForGeneration() {
+  const userPrompt = $('#prompt')?.value || '';
+  return buildCombinedPrompt(userPrompt);
 }
 
 // === Generate Tab ===
@@ -186,6 +436,9 @@ function showResults(images) {
     `;
     $('#results-grid').appendChild(card);
   });
+
+  // Reload history sidebar to show the new generation
+  loadHistorySidebar();
 }
 
 async function cancelGeneration() {
@@ -247,99 +500,82 @@ function populateLoraSelector() {
     activeLoras.map((l) => `<option value="${l._id}">${l.name} (${l.triggerWord})</option>`).join('');
 }
 
-// === History Tab ===
-async function loadHistory() {
+// === Asset Types ===
+async function loadAssetTypes() {
   try {
-    const result = await API.getHistory();
-    const items = result.data || result.items || result || [];
-    state.history = Array.isArray(items) ? items : [];
-    renderHistory();
+    const result = await API.getAssetTypes();
+    const items = result.data || result || [];
+    state.assetTypes = Array.isArray(items) ? items : [];
+    populateAssetTypeSelector();
+    updatePromptBuilder();
   } catch (error) {
-    console.error('Failed to load history:', error);
-    state.history = [];
-    renderHistory();
+    console.error('Failed to load asset types:', error);
+    state.assetTypes = [];
   }
 }
 
-function renderHistory() {
-  const list = $('#history-list');
-  
-  if (state.history.length === 0) {
-    list.innerHTML = '<div class="empty-state"><span class="empty-icon">📜</span><p>No generation history yet</p></div>';
-    return;
-  }
+function populateAssetTypeSelector() {
+  const select = $('#asset-type');
+  if (!select || state.assetTypes.length === 0) return;
 
-  list.innerHTML = state.history.map((item) => `
-    <div class="history-item">
-      <img class="history-item-thumb" src="${item.thumbnail || 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>'}" alt="">
-      <div class="history-item-content">
-        <div class="history-item-prompt">${item.prompt}</div>
-        <div class="history-item-meta">${new Date(item.created_at).toLocaleString()} • ${item.status}</div>
-      </div>
-      <span class="status-badge ${item.status}">${item.status}</span>
-    </div>
-  `).join('');
+  select.innerHTML = state.assetTypes
+    .filter((at) => at.isActive)
+    .map((at) => `<option value="${at._id}">${at.name}</option>`)
+    .join('');
+
+  // Set current asset type
+  if (state.assetTypes.length > 0) {
+    state.currentAssetType = state.assetTypes.find((at) => at.isActive) || null;
+  }
 }
 
-function setupHistory() {
-  $('#history-filter').addEventListener('change', async (e) => {
-    const status = e.target.value || null;
-    try {
-      const result = await API.getHistory(50, status);
-      state.history = result.data || result.items || [];
-      renderHistory();
-    } catch (error) {
-      console.error('Filter failed:', error);
+// === Combined Prompt Builder (Issue #11) ===
+function setupPromptBuilder() {
+  const assetTypeSelect = $('#asset-type');
+  const promptInput = $('#prompt');
+
+  if (assetTypeSelect) {
+    assetTypeSelect.addEventListener('change', () => {
+      const selectedId = assetTypeSelect.value;
+      state.currentAssetType = state.assetTypes.find((at) => at._id === selectedId) || null;
+      updatePromptBuilder();
+    });
+  }
+
+  if (promptInput) {
+    promptInput.addEventListener('input', updateCombinedPromptPreview);
+  }
+}
+
+function updatePromptBuilder() {
+  const prePromptLabel = $('#pre-prompt-label');
+  const postPromptLabel = $('#post-prompt-label');
+
+  if (state.currentAssetType) {
+    if (prePromptLabel) {
+      prePromptLabel.textContent = state.currentAssetType.prePrompt || '';
     }
-  });
-}
-
-// === Favorites Tab ===
-async function loadFavorites() {
-  try {
-    const result = await API.getFavorites();
-    const items = result.data || result.items || result || [];
-    state.favorites = Array.isArray(items) ? items : [];
-    renderFavorites();
-  } catch (error) {
-    console.error('Failed to load favorites:', error);
-    state.favorites = [];
-    renderFavorites();
-  }
-}
-
-function renderFavorites() {
-  const grid = $('#favorites-grid');
-  const empty = $('#favorites-empty');
-
-  if (state.favorites.length === 0) {
-    grid.classList.add('hidden');
-    empty.classList.remove('hidden');
-    return;
+    if (postPromptLabel) {
+      postPromptLabel.textContent = state.currentAssetType.postPrompt || '';
+    }
+  } else {
+    if (prePromptLabel) prePromptLabel.textContent = '';
+    if (postPromptLabel) postPromptLabel.textContent = '';
   }
 
-  empty.classList.add('hidden');
-  grid.classList.remove('hidden');
-  grid.innerHTML = state.favorites.map((fav) => `
-    <div class="image-card">
-      <img src="${API.baseUrl}${fav.image_url}" alt="">
-      <div class="image-overlay">
-        <button class="btn btn-small btn-secondary" onclick="downloadImage('${fav.image_url}')">⬇️</button>
-        <button class="btn btn-small btn-danger" onclick="removeFavorite('${fav.job_id}', ${fav.image_index})">❌</button>
-      </div>
-    </div>
-  `).join('');
+  updateCombinedPromptPreview();
 }
 
-async function removeFavorite(jobId, imageIndex) {
-  try {
-    await API.removeFavorite(jobId, imageIndex);
-    await loadFavorites();
-  } catch (error) {
-    alert('Failed to remove: ' + error.message);
-  }
-}
+function updateCombinedPromptPreview() {
+  const preview = $('#combined-prompt-preview');
+  const userPrompt = $('#prompt')?.value?.trim() || '';
 
-function setupFavorites() {
-  // No additional setup needed
+  if (!preview) return;
+
+  const pre = state.currentAssetType?.prePrompt || '';
+  const post = state.currentAssetType?.postPrompt || '';
+
+  // Build combined prompt following spec: "{pre} {user} {post}".strip()
+  const parts = [pre, userPrompt, post].filter((p) => p);
+  preview.textContent = parts.join(' ');
 }

--- a/app/index.html
+++ b/app/index.html
@@ -15,9 +15,6 @@
         <h1>Noisett</h1>
       </div>
       <nav class="nav">
-        <button class="nav-tab active" data-tab="generate">Generate</button>
-        <button class="nav-tab" data-tab="history">History</button>
-        <button class="nav-tab" data-tab="favorites">Favorites</button>
         <a href="director.html" class="nav-tab">Director</a>
       </nav>
       <div class="header-status">
@@ -28,21 +25,46 @@
 
     <!-- Main Content -->
     <main class="main">
-      <!-- Generate Tab -->
-      <section id="tab-generate" class="tab-content active">
-        <div class="generate-layout">
+      <div class="user-layout">
+        <!-- History Sidebar -->
+        <aside class="history-sidebar panel">
+          <div class="sidebar-header">
+            <h2 class="sidebar-title">History</h2>
+            <div class="history-filter">
+              <button id="filter-all" class="filter-btn active" data-filter="all">All</button>
+              <button id="filter-favorites" class="filter-btn" data-filter="favorites">Favorites</button>
+            </div>
+          </div>
+          <div id="history-list" class="history-sidebar-list">
+            <!-- History items populated dynamically -->
+          </div>
+          <div id="history-empty" class="empty-state-small">
+            <span class="empty-icon-small">🖼️</span>
+            <p>No generations yet</p>
+          </div>
+        </aside>
+
+        <!-- Main Generation Panel -->
+        <div class="generation-panel">
           <!-- Input Panel -->
           <div class="panel panel-input">
             <h2 class="panel-title">Create Assets</h2>
-            
+
             <div class="form-group">
               <label for="prompt">Describe what you need</label>
-              <textarea 
-                id="prompt" 
-                placeholder="A modern illustration of a person collaborating with AI..."
-                rows="4"
-              ></textarea>
-              <span class="char-count"><span id="char-current">0</span>/500</span>
+              <div class="prompt-builder">
+                <span id="pre-prompt-label" class="prompt-label prompt-label-pre"></span>
+                <textarea
+                  id="prompt"
+                  placeholder="A modern illustration of a person collaborating with AI..."
+                  rows="4"
+                ></textarea>
+                <span id="post-prompt-label" class="prompt-label prompt-label-post"></span>
+              </div>
+              <div class="prompt-builder-footer">
+                <span id="combined-prompt-preview" class="combined-prompt-preview"></span>
+                <span class="char-count"><span id="char-current">0</span>/500</span>
+              </div>
             </div>
 
             <div class="form-row">
@@ -98,38 +120,7 @@
             </div>
           </div>
         </div>
-      </section>
-
-      <!-- History Tab -->
-      <section id="tab-history" class="tab-content hidden">
-        <div class="panel">
-          <div class="panel-header">
-            <h2 class="panel-title">Generation History</h2>
-            <select id="history-filter" class="filter-select">
-              <option value="">All</option>
-              <option value="completed">Completed</option>
-              <option value="failed">Failed</option>
-            </select>
-          </div>
-          <div id="history-list" class="history-list">
-            <!-- History items populated dynamically -->
-          </div>
-        </div>
-      </section>
-
-      <!-- Favorites Tab -->
-      <section id="tab-favorites" class="tab-content hidden">
-        <div class="panel">
-          <h2 class="panel-title">Favorites</h2>
-          <div id="favorites-grid" class="image-grid">
-            <!-- Favorites populated dynamically -->
-          </div>
-          <div id="favorites-empty" class="empty-state hidden">
-            <span class="empty-icon">⭐</span>
-            <p>No favorites yet. Star images you want to keep!</p>
-          </div>
-        </div>
-      </section>
+      </div>
     </main>
   </div>
 

--- a/app/styles.css
+++ b/app/styles.css
@@ -231,6 +231,199 @@ body {
   gap: var(--space-xl);
 }
 
+/* =============================================================================
+   User Mode Layout (History Sidebar + Generation Panel)
+   ============================================================================= */
+
+.user-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: var(--space-xl);
+  height: calc(100vh - 140px);
+}
+
+/* History Sidebar */
+.history-sidebar {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.sidebar-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.history-filter {
+  display: flex;
+  gap: var(--space-xs);
+  padding: var(--space-xs);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+}
+
+.filter-btn {
+  flex: 1;
+  padding: var(--space-sm) var(--space-md);
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.filter-btn:hover {
+  color: var(--text-primary);
+}
+
+.filter-btn.active {
+  background: var(--accent-primary);
+  color: white;
+}
+
+.history-sidebar-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+/* History Sidebar Item */
+.history-sidebar-item {
+  display: flex;
+  gap: var(--space-md);
+  padding: var(--space-sm);
+  background: var(--bg-tertiary);
+  border: var(--border-subtle);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.history-sidebar-item:hover {
+  background: var(--bg-elevated);
+  border-color: var(--accent-primary);
+}
+
+.history-sidebar-item.active {
+  background: var(--bg-elevated);
+  border-color: var(--accent-primary);
+}
+
+.history-sidebar-thumb {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--bg-elevated);
+}
+
+.history-sidebar-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-xs);
+}
+
+.history-sidebar-prompt {
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+.history-sidebar-meta {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.history-sidebar-actions {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-xs);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.history-sidebar-item:hover .history-sidebar-actions {
+  opacity: 1;
+}
+
+.history-action-btn {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+}
+
+.history-action-btn:hover {
+  background: var(--accent-primary);
+  color: white;
+}
+
+.history-action-btn.favorited {
+  color: var(--warning);
+}
+
+.history-action-btn.delete:hover {
+  background: var(--danger);
+}
+
+/* Empty State Small (for sidebar) */
+.empty-state-small {
+  text-align: center;
+  padding: var(--space-xl) var(--space-md);
+  color: var(--text-secondary);
+}
+
+.empty-icon-small {
+  font-size: 2rem;
+  display: block;
+  margin-bottom: var(--space-sm);
+  opacity: 0.5;
+}
+
+.empty-state-small p {
+  font-size: 0.875rem;
+}
+
+/* Generation Panel */
+.generation-panel {
+  display: grid;
+  grid-template-columns: 400px 1fr;
+  gap: var(--space-xl);
+}
+
 .panel-input {
   display: flex;
   flex-direction: column;
@@ -863,6 +1056,91 @@ code {
   max-width: 120px;
 }
 
+/* =============================================================================
+   Combined Prompt Builder Component
+   ============================================================================= */
+
+.prompt-builder {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  position: relative;
+}
+
+.prompt-label {
+  display: block;
+  font-size: 0.8125rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  min-height: 1.5rem;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.prompt-label:empty {
+  display: none;
+}
+
+.prompt-label-pre {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+.prompt-label-post {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-top: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+/* When pre-prompt is visible, adjust textarea border radius */
+.prompt-builder .prompt-label-pre:not(:empty) + textarea {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+/* When post-prompt is visible, adjust textarea border radius */
+.prompt-builder textarea:has(+ .prompt-label-post:not(:empty)) {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.prompt-builder textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.prompt-builder-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-md);
+  margin-top: var(--space-xs);
+}
+
+.combined-prompt-preview {
+  flex: 1;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-style: italic;
+  line-height: 1.4;
+  max-height: 2.8em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.combined-prompt-preview:empty::before {
+  content: 'Combined prompt will appear here';
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+
 /* Utilities */
 .hidden {
   display: none !important;
@@ -871,6 +1149,19 @@ code {
 /* Responsive */
 @media (max-width: 1024px) {
   .generate-layout, .loras-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .user-layout {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+
+  .history-sidebar {
+    max-height: 300px;
+  }
+
+  .generation-panel {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- Add left sidebar with generation history displaying thumbnails and prompts
- Add favorites filter toggle at top of sidebar for quick filtering
- Include action buttons (favorite, delete, regenerate) with stubs for Issue #13
- Add combined prompt builder UI component per spec section 3.2
- Refactor from tab-based navigation to sidebar layout for User Mode

## Changes
- **app/index.html**: Replaced tab-based structure with history sidebar + generation panel layout
- **app/styles.css**: Added 200+ lines for history sidebar, filter buttons, sidebar items, and prompt builder styles
- **app/app.js**: Updated state management, removed old tab functions, added sidebar rendering and filter logic

## Test plan
- [ ] Verify history sidebar displays on page load
- [ ] Verify favorites filter toggles correctly
- [ ] Verify sidebar items show thumbnails, prompts, and relative timestamps
- [ ] Verify action buttons appear on hover
- [ ] Verify responsive layout works on mobile (sidebar collapses)
- [ ] Verify combined prompt preview updates when typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)